### PR TITLE
Fix Trivy scanner image repository path

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
@@ -141,11 +141,11 @@ spec:
     # Additional OIDC setup can be done via the harbor-oidc-init.yaml job
 
     # Trivy vulnerability scanner configuration
-    # Using octohelm/trivy-adapter-photon from GHCR which supports ARM64
+    # Using octohelm/harbor/trivy-adapter-photon from GHCR which supports ARM64
     trivy:
       enabled: true
       image:
-        repository: ghcr.io/octohelm/trivy-adapter-photon
+        repository: ghcr.io/octohelm/harbor/trivy-adapter-photon
         tag: v2.13.0
       resources:
         requests:


### PR DESCRIPTION
- Correct image repository from ghcr.io/octohelm/trivy-adapter-photon to ghcr.io/octohelm/harbor/trivy-adapter-photon
- Resolves ImagePullBackOff error for Trivy vulnerability scanner
- Ensures proper ARM64 compatibility for Harbor Trivy component