### PR TITLE
Add MinIO operator and resources to kustomization.yaml

### DIFF
--- a/clusters/k3s-cluster/apps/minio-operator/operator-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/minio-operator/operator-helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
         name: minio
         namespace: flux-system
   install:
+    createNamespace: false
     remediation:
       retries: 3
   upgrade:

--- a/clusters/k3s-cluster/kustomization.yaml
+++ b/clusters/k3s-cluster/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
   - flux-system
   - apps/harbor
+  - apps/minio-operator
+  - apps/minio


### PR DESCRIPTION
- Include MinIO operator and MinIO resources in the kustomization file.
- Update operator-helmrelease.yaml to set createNamespace to false for MinIO installation.