### PR TITLE
Add Ingress resources for MinIO Console and API

### DIFF
--- a/clusters/k3s-cluster/apps/minio/ingress.yaml
+++ b/clusters/k3s-cluster/apps/minio/ingress.yaml
@@ -1,0 +1,55 @@
+---
+# Ingress for MinIO Console
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console-ingress
+  namespace: minio-tenant
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  tls:
+    - secretName: minio-console-tls
+      hosts:
+        - minio-console.theedgeworks.ai
+  rules:
+    - host: minio-console.theedgeworks.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-tenant-console
+                port:
+                  number: 9090
+---
+# Ingress for MinIO API
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-api-ingress
+  namespace: minio-tenant
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  tls:
+    - secretName: minio-tls
+      hosts:
+        - minio.theedgeworks.ai
+  rules:
+    - host: minio.theedgeworks.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-tenant
+                port:
+                  number: 9000
+

--- a/clusters/k3s-cluster/apps/minio/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/minio/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - tenant.yaml
+  - ingress.yaml
 
 namespace: minio-tenant
 

--- a/clusters/k3s-cluster/apps/minio/tenant.yaml
+++ b/clusters/k3s-cluster/apps/minio/tenant.yaml
@@ -64,40 +64,6 @@ spec:
   features:
     bucketDNS: false
   
-  # Ingress configuration for MinIO Console
-  consoleIngress:
-    enabled: true
-    ingressClassName: traefik
-    annotations:
-      traefik.ingress.kubernetes.io/router.tls: "true"
-      traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    hosts:
-      - host: minio-console.theedgeworks.ai
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - secretName: minio-console-tls
-        hosts:
-          - minio-console.theedgeworks.ai
-  
-  # Ingress configuration for MinIO API
-  minioIngress:
-    enabled: true
-    ingressClassName: traefik
-    annotations:
-      traefik.ingress.kubernetes.io/router.tls: "true"
-      traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    hosts:
-      - host: minio.theedgeworks.ai
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - secretName: minio-tls
-        hosts:
-          - minio.theedgeworks.ai
-  
   # Resource limits for Raspberry Pi
   resources:
     requests:


### PR DESCRIPTION
- Introduced separate Ingress configurations for MinIO Console and API in ingress.yaml.
- Updated kustomization.yaml to include the new ingress resource.
- Removed inline Ingress configuration from tenant.yaml to streamline resource management.