### PR TITLE
Add empty tenants array to MinIO operator Helm release configuration

### DIFF
--- a/clusters/k3s-cluster/apps/minio-operator/operator-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/minio-operator/operator-helmrelease.yaml
@@ -42,3 +42,4 @@ spec:
       limits:
         memory: "256Mi"
         cpu: "200m"
+    tenants : []    


### PR DESCRIPTION
- Introduced an empty tenants array in operator-helmrelease.yaml to allow for future tenant definitions.
- This change prepares the configuration for multi-tenant support in MinIO.