### PR TITLE
chore: update container image tags

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.1.5
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.1.5
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.1.5
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.1.5
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
             command: ["/home/runner/run.sh"]
             # Higher resources — bootc image builds with embedded container
             # images are CPU and memory intensive (skopeo pulls ~30 images

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.1.5
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/devpi/deployment.yaml
+++ b/clusters/k3s-cluster/apps/devpi/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: devpi-server
-          image: harbor.theedgeworks.ai/base/devpi:v0.4.0
+          image: harbor.theedgeworks.ai/base/devpi:v0.4.1
           imagePullPolicy: Always
           env:
             - name: DEVPI_SERVERDIR

--- a/clusters/k3s-cluster/apps/harbor/redis.yaml
+++ b/clusters/k3s-cluster/apps/harbor/redis.yaml
@@ -30,7 +30,7 @@ spec:
         node-role.apps: "true"
       containers:
       - name: redis
-        image: redis:7-alpine
+        image: redis:8-alpine
         ports:
         - containerPort: 6379
         volumeMounts:

--- a/clusters/k3s-cluster/apps/keycloak/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
       enabled: true
       image:
         repository: docker.io/busybox
-        tag: "1.32"
+        tag: "1.37.0"
       securityContext:
         allowPrivilegeEscalation: false
         runAsUser: 1000

--- a/clusters/k3s-cluster/apps/minio/tenant.yaml
+++ b/clusters/k3s-cluster/apps/minio/tenant.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minio-tenant
   namespace: minio-tenant
 spec:
-  image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z
+  image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
   imagePullPolicy: IfNotPresent
   pools:
     - servers: 3

--- a/image-tags.toml
+++ b/image-tags.toml
@@ -1,0 +1,88 @@
+# Container image tag tracking for core/infra.
+# Source of truth for /update-tags command.
+# After updating tags in deployment files, update this file to match.
+
+# ─── Internal images (Harbor) ────────────────────────────────────────────────
+
+[actions-runner]
+registry = "harbor.theedgeworks.ai/base/actions-runner"
+github = "RamaEdge/base"
+tag = "v0.4.1"
+files = [
+  "clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml",
+  "clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml",
+  "clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml",
+  "clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml",
+  "clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml",
+]
+# Direct image reference: image: harbor.theedgeworks.ai/base/actions-runner:<tag>
+update_style = "inline"
+
+[devpi]
+registry = "harbor.theedgeworks.ai/base/devpi"
+github = "RamaEdge/base"
+tag = "v0.4.1"
+files = ["clusters/k3s-cluster/apps/devpi/deployment.yaml"]
+# Direct image reference: image: harbor.theedgeworks.ai/base/devpi:<tag>
+update_style = "inline"
+
+# ─── External images ─────────────────────────────────────────────────────────
+
+[harbor]
+registry = "ghcr.io/octohelm/harbor/harbor-core"
+tag = "v2.14.0"
+tag_format = "v{semver}"
+multi_image = [
+  "ghcr.io/octohelm/harbor/harbor-core",
+  "ghcr.io/octohelm/harbor/harbor-portal",
+  "ghcr.io/octohelm/harbor/harbor-jobservice",
+  "ghcr.io/octohelm/harbor/registry-photon",
+  "ghcr.io/octohelm/harbor/harbor-registryctl",
+  "ghcr.io/octohelm/harbor/nginx-photon",
+  "ghcr.io/octohelm/harbor/harbor-db",
+  "ghcr.io/octohelm/harbor/harbor-exporter",
+  "ghcr.io/octohelm/harbor/trivy-adapter-photon",
+]
+files = ["clusters/k3s-cluster/apps/harbor/helmrelease.yaml"]
+# Helm values: image.tag under multiple sections
+update_style = "helm_tag"
+
+[redis]
+registry = "docker.io/library/redis"
+tag = "8-alpine"
+tag_format = "{major}-alpine"
+files = ["clusters/k3s-cluster/apps/harbor/redis.yaml"]
+# Direct image reference: image: redis:<tag>
+update_style = "inline"
+
+[minio-operator]
+registry = "quay.io/minio/operator"
+tag = "v7.1.1"
+tag_format = "v{semver}"
+multi_image = [
+  "quay.io/minio/operator",
+  "quay.io/minio/console",
+]
+files = ["clusters/k3s-cluster/apps/minio-operator/operator-helmrelease.yaml"]
+update_style = "helm_tag"
+
+[minio]
+registry = "quay.io/minio/minio"
+tag = "RELEASE.2025-09-07T16-13-09Z"
+tag_format = "RELEASE.{date}"
+files = ["clusters/k3s-cluster/apps/minio/tenant.yaml"]
+update_style = "inline"
+
+[busybox]
+registry = "docker.io/library/busybox"
+tag = "1.37.0"
+tag_format = "{semver}"
+files = ["clusters/k3s-cluster/apps/keycloak/helmrelease.yaml"]
+update_style = "helm_tag"
+
+[otel-collector]
+registry = "docker.io/otel/opentelemetry-collector-contrib"
+tag_format = "{semver}"
+files = ["clusters/k3s-cluster/apps/opentelemetry-collector/helmrelease.yaml"]
+update_style = "helm_repository"
+# Note: tag managed by chart version; only repository is pinned in values


### PR DESCRIPTION
## Summary
- **actions-runner**: v0.1.5 → v0.4.1 (5 runner scale set files)
- **devpi**: v0.4.0 → v0.4.1
- **redis**: 7-alpine → 8-alpine (Harbor dependency)
- **minio**: RELEASE.2025-04-08T15-41-24Z → RELEASE.2025-09-07T16-13-09Z
- **busybox**: 1.32 → 1.37.0 (Keycloak dbchecker)

## Test plan
- [ ] Verify FluxCD reconciles all HelmReleases successfully
- [ ] Confirm actions-runner pods start and pick up jobs
- [ ] Confirm devpi pod starts and `/+api` health check passes
- [ ] Confirm Harbor redis pod starts with new major version
- [ ] Confirm MinIO tenant reconciles with new RELEASE
- [ ] Confirm Keycloak dbchecker init container runs with new busybox

🤖 Generated with [Claude Code](https://claude.com/claude-code)