### PR TITLE
Add renovate-runner-set scaleset

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - modbus-runner-set.yaml
   - opcua-runner-set.yaml
   - os-builder-runner-set.yaml
+  - renovate-runner-set.yaml

--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -1,0 +1,74 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: renovate-runner-set
+  namespace: flux-system
+spec:
+  interval: 5m
+  targetNamespace: arc-runners
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: 0.13.1
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller
+        namespace: flux-system
+  install:
+    createNamespace: false
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    runnerScaleSetName: renovate-runner-set
+    # GitHub configuration
+    githubConfigUrl: "https://github.com/ramaedge"
+    # Reference to pre-existing secret in arc-runners namespace
+    # Secret must have key: github_token
+    githubConfigSecret: arc-runner-set-secret
+
+    # Cron-driven workload — typically idle, no need for parallelism.
+    minRunners: 0
+    maxRunners: 1
+
+    # Runner pod template
+    template:
+      spec:
+        nodeSelector:
+          node-role.runners: "true"
+        securityContext:
+          fsGroup: 1001
+        containers:
+          - name: runner
+            # TODO: pin to the next base release tag once cut (e.g. v0.5.0).
+            # `latest` works because the base build pipeline maintains a
+            # multi-arch :latest manifest, but pinning matches the convention
+            # used by the other runner sets in this directory.
+            image: harbor.theedgeworks.ai/base/actions-runner-renovate:latest
+            command: ["/home/runner/run.sh"]
+            resources:
+              requests:
+                cpu: "500m"
+                memory: "1Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+
+        # Renovate clones every autodiscovered repo into _work; 5Gi is tight
+        # for ramaedge/* — bump to 10Gi.
+        volumes:
+          - name: work
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes:
+                    - ReadWriteOnce
+                  storageClassName: longhorn
+                  resources:
+                    requests:
+                      storage: 10Gi

--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -42,11 +42,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            # TODO: pin to the next base release tag once cut (e.g. v0.5.0).
-            # `latest` works because the base build pipeline maintains a
-            # multi-arch :latest manifest, but pinning matches the convention
-            # used by the other runner sets in this directory.
-            image: harbor.theedgeworks.ai/base/actions-runner-renovate:latest
+            image: harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:


### PR DESCRIPTION
## Summary

- New `renovate-runner-set.yaml` HelmRelease — dedicated `gha-runner-scale-set` for the Renovate workflow.
- `min=0 / max=1` (cron-driven, no parallelism needed), 10Gi ephemeral workspace because Renovate clones every autodiscovered repo under `ramaedge/*`.
- Runner image: `harbor.theedgeworks.ai/base/actions-runner-renovate` (added in the base PR) — has Node, Rust, Python+poetry+pipenv, Helm, Kustomize baked in so Renovate can resolve lockfile updates without DinD.
- Uses the existing `arc-runner-set-secret` for GitHub auth.

## Why

The Renovate workflow has been failing since switching to `arc-runner-set` because `renovatebot/github-action` requires `/var/run/docker.sock` and our runners use podman, not docker. Rather than add docker to the standard runner, this PR adds a purpose-built scaleset (matching the existing convention — `actions-runner-rust`, `actions-runner-dependabot`, etc.) that runs Renovate as a plain Node CLI.

## Rollout

Depends on:
- `ramaedge/base#8` — must merge and get a new `v*` tag cut so the `actions-runner-renovate` image exists in Harbor before this can roll out.
- After this merges and Flux reconciles, `ramaedge/renovate-config` PR can flip the workflow to `runs-on: renovate-runner-set`.

## Notes

The image tag is `:latest` for now. Recommend bumping to the next versioned tag (matching `:v0.4.1` convention used by the other runner sets) once the base release is cut — flip tag in this file before merging if you prefer to land it pinned from day one.

## Test plan

- [ ] After merge, check Flux reconciles the new HelmRelease successfully (\`flux get helmreleases -n flux-system | grep renovate\`)
- [ ] \`kubectl get autoscalingrunnersets -n arc-runners\` shows \`renovate-runner-set\`
- [ ] Manually dispatch the Renovate workflow in \`ramaedge/renovate-config\` (after that PR merges) and confirm a runner pod spawns and the job completes