### PR TITLE
Bump actions-runner image to v0.5.1 across runner sets

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.5.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.5.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.5.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.5.1
             command: ["/home/runner/run.sh"]
             # Higher resources — bootc image builds with embedded container
             # images are CPU and memory intensive (skopeo pulls ~30 images

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner:v0.4.1
+            image: harbor.theedgeworks.ai/base/actions-runner:v0.5.1
             command: ["/home/runner/run.sh"]
             resources:
               requests:


### PR DESCRIPTION
## Summary

Refresh the `actions-runner` image pin from `v0.4.1` → `v0.5.1` on every existing scaleset:

- `arc-runner-set` (`runner-scale-set-helmrelease.yaml`)
- `code-quality-runner-helmrelease.yaml`
- `modbus-runner-set.yaml`
- `opcua-runner-set.yaml`
- `os-builder-runner-set.yaml`

5-line, 5-file change.

## What's actually different in v0.5.1

The `actions-runner` Containerfile didn't change between v0.4.1 and v0.5.1 — same podman, same Python 3.11/3.12/3.13, same Trivy. The only delta is whatever drifted in the `ghcr.io/actions/actions-runner` upstream base layer when v0.5.1 rebuilt, which gets us a fresher GitHub runner agent.

## Why now

Companion to the renovate-runner-set PR (#12) which pins the new \`actions-runner-renovate:v0.5.1\` image. Bumping the existing scalesets at the same time keeps all runner sets on the same base release.

## Rollout

Flux reconciles → ARC controller updates the AutoscalingRunnerSet specs → new runner pods spawn on v0.5.1, in-flight runners keep running on v0.4.1 and drain naturally.

## Test plan

- [ ] After Flux reconciles, \`kubectl get pods -n arc-runners -o jsonpath='{.items[*].spec.containers[*].image}' | tr ' ' '\n' | sort -u\` shows only v0.5.1 references for any new pods
- [ ] An existing CI job on each scaleset (general arc-runner-set, code-quality, os-builder, modbus, opcua) completes without regression