### PR TITLE
Bump renovate-runner-set image v0.5.1 → v0.5.2 (Node 24)

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -42,7 +42,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.1
+            image: harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.2
             command: ["/home/runner/run.sh"]
             resources:
               requests:


### PR DESCRIPTION
## Summary
- `renovate-runner-set.yaml`: pin runner image to `v0.5.2`, which ships Node 24.

## Why
Renovate 43.x requires Node ≥24.11 — every scheduled run on `renovate-runner-set` currently exits 1 with `"Unsupported node environment detected"`. Failing run: https://github.com/RamaEdge/renovate-config/actions/runs/24960713658

## Blocked on
- [ ] base PR https://github.com/RamaEdge/base/pull/10 merged
- [ ] base tagged `v0.5.2` and `harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.2` published

**Mark this ready-for-review only after the image is in Harbor** — Flux will reconcile within ~10 min and pull the new tag; if it doesn't exist yet, the scale set pods will fail ImagePull and renovate stops entirely.

## Test plan
- [ ] After Flux reconcile, `kubectl -n actions-runner-system get pods -l actions.github.com/scale-set-name=renovate-runner-set` shows new pods Running on the v0.5.2 image
- [ ] Trigger a `workflow_dispatch` on `renovate-config/.github/workflows/renovate.yml` and confirm exit 0