### PR TITLE
security: restrict keycloak postgres network policy to Keycloak app only

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -42,7 +42,7 @@ spec:
           fsGroup: 1001
         containers:
           - name: runner
-            image: harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.1
+            image: harbor.theedgeworks.ai/base/actions-runner-renovate:v0.5.2
             command: ["/home/runner/run.sh"]
             resources:
               requests:

--- a/clusters/k3s-cluster/apps/keycloak/postgres-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/postgres-helmrelease.yaml
@@ -46,3 +46,14 @@ spec:
         limits:
           cpu: 500m
           memory: 512Mi
+      networkPolicy:
+        enabled: true
+        allowExternal: false
+        extraIngress:
+          - from:
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: keycloakx
+            ports:
+              - port: 5432
+                protocol: TCP


### PR DESCRIPTION
## Summary

Bug fix for an existing NetworkPolicy that looks like access control but enforces nothing.

The Bitnami postgresql chart defaults `networkPolicy.allowExternal: true`, which renders an ingress rule with **no `from:` selector** — port 5432 is open to any pod in any namespace. Found during STRIDE security review of the cluster.

## Change

Override Helm values:
- `primary.networkPolicy.allowExternal: false`
- `primary.networkPolicy.extraIngress` allowing pods labeled `app.kubernetes.io/name: keycloakx`

## Effect

After Flux reconciles, the rendered NetworkPolicy will require a source-selector match — closing the lateral-movement path from any breached pod (e.g., chromadb, devpi) to the Keycloak credential store.

## Test plan

- [ ] Verify Flux reconciles HelmRelease without error: `flux get hr -n flux-system keycloak-db`
- [ ] Verify rendered policy has `from:` clause: `kubectl get netpol -n keycloak keycloak-postgresql -o yaml | yq '.spec.ingress'`
- [ ] Verify Keycloak still serves OIDC: `curl -sI https://auth.theedgeworks.ai/realms/master`
- [ ] Verify cross-namespace access is blocked from a non-keycloak pod (timeout expected):
  ```bash
  kubectl run -n default --rm -it --image=alpine/curl curl-test -- \
    nc -zv keycloak-postgresql.keycloak.svc.cluster.local 5432
  ```

## Rollback

`git revert` — Flux will re-render with `allowExternal: true` on next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)