### PR TITLE
security(netpol): Pattern A rollout — devpi, chromadb, arc-runners

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - runner-namespace.yaml
+  - runner-networkpolicy.yaml
   - operator-helmrelease.yaml
   - runner-scale-set-helmrelease.yaml
   - code-quality-runner-helmrelease.yaml

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: arc-runners
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/clusters/k3s-cluster/apps/chromadb/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/chromadb/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - networkpolicy.yaml

--- a/clusters/k3s-cluster/apps/chromadb/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/chromadb/networkpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: chromadb
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: chromadb
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: chromadb
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: chromadb
+spec:
+  podSelector:
+    matchLabels:
+      app: chromadb
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8000

--- a/clusters/k3s-cluster/apps/devpi/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/devpi/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - networkpolicy.yaml

--- a/clusters/k3s-cluster/apps/devpi/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/devpi/networkpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: devpi
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: devpi
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: devpi
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: devpi
+spec:
+  podSelector:
+    matchLabels:
+      app: devpi
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3141


### PR DESCRIPTION
## Summary

Pattern A NetworkPolicy rollout for three low-blast-radius namespaces. Continues the STRIDE-driven netpol expansion started by PR #16 (keycloak postgres) and infra-core PR #3 (oauth2-proxy redis).

## What is Pattern A

Default-deny ingress + three guest-list allows:

1. **`allow-same-namespace`** — pods in the namespace can talk to each other.
2. **`allow-monitoring`** — Prometheus + OTel agent can scrape any pod (cross-namespace from `monitoring/`).
3. **`allow-ingress-nginx`** — public traffic via the ingress controller reaches the app pod on its service port.
4. **`default-deny-ingress`** — empty guest list for everything else.

After Flux reconciles, lateral movement from any other namespace into these three is blocked.

## Per-namespace shape

| Namespace | Pattern | Public ingress | Service port |
|---|---|---|---|
| `devpi` | A (full 4 policies) | `pypi.theedgeworks.ai` | 3141 |
| `chromadb` | A (full 4 policies) | `claudedb.theedgeworks.ai` | 8000 |
| `arc-runners` | C (single deny-ingress) | none | n/a |

`arc-runners` only gets `default-deny-ingress` because runner pods receive no inbound traffic — they poll GitHub Actions outbound for work. Egress remains unrestricted (CI builds need internet, Harbor, devpi, GitHub).

## Test plan

After Flux reconciles:

- [ ] All four policies applied in each namespace:
  ```bash
  kubectl get netpol -n devpi
  kubectl get netpol -n chromadb
  kubectl get netpol -n arc-runners
  ```
- [ ] Public services still serve:
  ```bash
  curl -sI https://pypi.theedgeworks.ai           # devpi
  curl -sI https://claudedb.theedgeworks.ai       # chromadb (auth required, 401 expected)
  ```
- [ ] Cross-namespace direct access from `default` ns is blocked (timeout expected):
  ```bash
  kubectl run -n default --rm -i --restart=Never --image=alpine/curl netpol-test \
    --command -- sh -c "timeout 5 nc -zvw 3 devpi.devpi.svc.cluster.local 3141"
  # expect: EXIT=1, no "open"
  ```
- [ ] Prometheus is still scraping these namespaces (Grafana dashboard for kube-prometheus-stack should show no new "down" targets).
- [ ] CI workflows still pull/push to Harbor and pip-install from devpi (next workflow run will validate this implicitly).

## Rollback

`git revert` the merge commit. Each namespace's policies are in their own commit for selective revert if needed.

## Next

PRs to follow (separate, in order):
- arcanon Pattern A — separate repo (`arcanon-hub`), needs manual `kubectl apply -k` since not GitOps-managed
- keycloak + oauth2-proxy Pattern A
- harbor Pattern A
- monitoring Pattern B (Pattern A + OTLP-from-cluster allow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)