### PR TITLE
security(netpol): Pattern A for keycloak

### DIFF
--- a/clusters/k3s-cluster/apps/keycloak/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - namespace.yaml
   - postgres-helmrelease.yaml
   - helmrelease.yaml
+  - networkpolicy.yaml
 # Note: postgres.yaml is unused - using Bitnami PostgreSQL HelmRelease instead

--- a/clusters/k3s-cluster/apps/keycloak/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/networkpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: keycloak
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: keycloak
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: keycloak
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: keycloakx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080


### PR DESCRIPTION
## Summary

Adds Pattern A NetworkPolicies to the `keycloak` namespace. Continues the netpol expansion (after PRs #16, #17 in this repo, PR #3 in infra-core).

## Pattern A in keycloak

| Policy | Selects | Allows |
|---|---|---|
| `default-deny-ingress` | all pods | (empty — bouncer at every door) |
| `allow-same-namespace` | all pods | from any pod in `keycloak` ns |
| `allow-monitoring` | all pods | from `monitoring` ns (any port) |
| `allow-ingress-nginx` | `app.kubernetes.io/name: keycloakx` | from `ingress-nginx` ns on port 8080 |

The existing chart-managed `keycloak-postgresql` policy (tightened in #16) remains and stays the tighter restriction on the postgres pod (keycloakx-only on 5432). Pattern A's `allow-same-namespace` adds a strictly looser allow for postgres ingress, but the effective access is unchanged because keycloakx is the only other pod in the namespace.

## Test plan

- [ ] All four policies present: `kubectl get netpol -n keycloak`
- [ ] OIDC still serves: `curl -sI https://auth.theedgeworks.ai/realms/master` → 200
- [ ] Apps depending on Keycloak still authenticate (Longhorn UI via oauth2-proxy is the canary — should redirect to login then succeed)
- [ ] Cross-ns deny test: `kubectl run -n default --rm -i --restart=Never --image=alpine/curl netpol-test --command -- sh -c "timeout 5 nc -zvw 3 keycloak-keycloak-keycloakx-http.keycloak.svc.cluster.local 80; echo EXIT=\$?"` → EXIT=1

## Rollback

`git revert` — Flux re-renders without these policies on next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)