### PR TITLE
security(netpol): Pattern A for harbor

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/harbor/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - redis.yaml
   - helmrelease.yaml
+  - networkpolicy.yaml

--- a/clusters/k3s-cluster/apps/harbor/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/harbor/networkpolicy.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: harbor
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: harbor
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: harbor
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: harbor
+spec:
+  podSelector:
+    matchLabels:
+      app: harbor
+      release: harbor-harbor
+    matchExpressions:
+      - key: component
+        operator: In
+        values:
+          - core
+          - portal
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080


### PR DESCRIPTION
## Summary

Adds Pattern A NetworkPolicies to the `harbor` namespace. Highest-blast-radius single namespace in the netpol effort because every kubelet on every node pulls images via Harbor.

## Pattern A in harbor

| Policy | Selects | Allows |
|---|---|---|
| `default-deny-ingress` | all pods | (bouncer at every door) |
| `allow-same-namespace` | all pods | from any pod in `harbor` ns (covers all intra-Harbor flows) |
| `allow-monitoring` | all pods | from `monitoring` ns |
| `allow-ingress-nginx` | `app=harbor,release=harbor-harbor,component∈{core,portal}` | from `ingress-nginx` ns on port 8080 |

Pods affected by `allow-ingress-nginx`:
- `harbor-harbor-core` — handles `/api/`, `/v2/` (registry), `/service/`, `/c/`
- `harbor-harbor-portal` — handles `/` (UI)

Internal flows preserved by `allow-same-namespace`:
- registry ↔ core, registry ↔ redis (storage layer)
- jobservice ↔ core, jobservice ↔ registry, jobservice ↔ database, jobservice ↔ redis
- exporter ↔ core, exporter ↔ database, exporter ↔ redis (metrics aggregation)
- trivy ↔ core, trivy ↔ database (vuln scan results)
- portal ↔ core (UI proxies API calls)

## Risk

This is the most consequential single PR in the netpol effort. If the rule for ingress-nginx → core/portal is wrong, every kubelet's next image pull cluster-wide fails. Verified the selector matches both target pods before merging.

## Test plan

After Flux reconciles:

- [ ] All four policies present: `kubectl get netpol -n harbor`
- [ ] **Public Harbor UI loads:** `curl -sI https://harbor.theedgeworks.ai` → 200 or 302
- [ ] **Registry V2 API responds:** `curl -sI https://harbor.theedgeworks.ai/v2/` → 200 or 401 (auth challenge)
- [ ] **Image pull from any node still works:**
  ```bash
  kubectl run -n default --rm -i --restart=Never --image=harbor.theedgeworks.ai/base/devpi:v0.4.1 \
    --image-pull-policy=Always pull-test --command -- echo OK
  # expect: OK printed, pod completes; pull error == regression
  ```
- [ ] **CI workflow** — next ramaedge/base or ramaedge/infra build that pushes to Harbor should succeed
- [ ] **Cross-ns deny test from `default`:**
  ```bash
  kubectl run -n default --rm -i --restart=Never --image=alpine/curl netpol-test \
    --command -- sh -c "timeout 5 nc -zvw 3 harbor-harbor-core.harbor.svc.cluster.local 80; echo EXIT=\$?"
  # expect: EXIT=1 (cross-ns blocked)
  ```

## Rollback

`git revert` — Flux re-renders without these policies on next reconcile. If image pulls break, **revert immediately** rather than diagnosing live; image-pull failures cascade fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)