### PR TITLE
security(netpol): Pattern B for monitoring (final netpol PR)

### DIFF
--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - helmrelease.yaml
+  - networkpolicy.yaml
   # Grafana Dashboards (ConfigMaps - no CRD dependency)
   - dashboard-harbor.yaml
   - dashboard-nginx-ingress.yaml

--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/networkpolicy.yaml
@@ -76,8 +76,14 @@ spec:
     - Ingress
   ingress:
     - from:
+        # Home subnet covering all current and future cluster nodes.
+        # The K8s API server calls this webhook from the control-plane
+        # host network, so source IP is the node IP (not a pod IP) — only
+        # ipBlock can match. Using the /24 instead of a single /32 means
+        # the rule survives node IP changes, control-plane migrations, or
+        # additional control-plane nodes joining the cluster.
         - ipBlock:
-            cidr: 192.168.0.14/32
+            cidr: 192.168.0.0/24
       ports:
         - protocol: TCP
           port: 10250

--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/networkpolicy.yaml
@@ -1,0 +1,83 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx-grafana
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/instance: kube-prometheus-stack
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-otlp-from-cluster
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-webhook
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app: kube-prometheus-stack-operator
+      release: kube-prometheus-stack
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.14/32
+      ports:
+        - protocol: TCP
+          port: 10250


### PR DESCRIPTION
## Summary

Final NetworkPolicy PR in the STRIDE-driven netpol effort. Adds Pattern B (Pattern A + two extras) to the `monitoring` namespace.

## Pattern B in monitoring

| Policy | Selects | Allows |
|---|---|---|
| `default-deny-ingress` | all pods | (bouncer at every door) |
| `allow-same-namespace` | all pods | from any pod in `monitoring` ns |
| `allow-ingress-nginx-grafana` | Grafana pods | from `ingress-nginx` ns on port 3000 |
| `allow-otlp-from-cluster` | OTel collector pods | from **any namespace** on ports 4317/4318 (covers internal OTLP + public ingress) |
| `allow-operator-webhook` | prometheus-operator pod | from `192.168.0.14/32` (rpi-01 control-plane node) on port 10250 |

## Why no separate ingress-nginx allow for OTel collector

The `allow-otlp-from-cluster` rule uses `namespaceSelector: {}` which matches **every namespace**, including `ingress-nginx`. So both the internal OTLP push (apps in any ns → collector) and the public path (`otel.theedgeworks.ai` → ingress-nginx → collector) are covered by the single rule.

## Why the operator-webhook rule

`prometheus-operator` runs an admission webhook on port 10250 that validates `PrometheusRule` and `AlertmanagerConfig` resources. The K8s API server calls it. The API server runs from the control-plane node (rpi-01, 192.168.0.14) on host network, so source IP is the node IP — `ipBlock` is the right tool.

Currently the operator pod is on rpi-01, so traffic stays node-local and bypasses kube-router enforcement anyway. But if the operator gets rescheduled to a worker, the webhook would break without this rule.

## What's NOT affected

- **Node exporter** (DaemonSet, hostNetwork) — bypasses NetworkPolicy entirely. Prometheus → node-exporter:9100 still works.
- **Prometheus scraping outbound** — egress from monitoring ns is unrestricted (we only write Ingress policies).

## Test plan

After Flux reconciles:

- [ ] All 5 policies present: `kubectl get netpol -n monitoring`
- [ ] **Grafana UI:** `curl -sI https://monitor.theedgeworks.ai` → 200 or 302
- [ ] **OTel public ingress:** `curl -sI https://otel.theedgeworks.ai/v1/logs` → 405 (method not allowed for GET, but reachable)
- [ ] **Internal OTLP push works:** if any cluster app sends OTLP to `opentelemetry-collector.monitoring.svc.cluster.local:4318`, it should succeed
- [ ] **Prometheus scraping isn't dropping targets:** Grafana → kube-prometheus-stack overview, no `up == 0` for cluster targets
- [ ] **PrometheusRule validation still works:**
  ```bash
  kubectl apply --dry-run=server -f - <<EOF
  apiVersion: monitoring.coreos.com/v1
  kind: PrometheusRule
  metadata:
    name: webhook-test
    namespace: monitoring
  spec:
    groups:
      - name: test
        rules:
          - alert: Test
            expr: vector(1)
  EOF
  # expect: created (dry-run)
  # if "context deadline exceeded" or "connection refused" — webhook is being blocked
  ```
- [ ] **Cross-ns deny test:**
  ```bash
  kubectl run -n default --rm -i --restart=Never --image=alpine/curl netpol-test \
    --command -- sh -c "timeout 5 nc -zvw 3 prometheus-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local 9090; echo EXIT=\$?"
  # expect: EXIT=1
  ```

## Rollback

`git revert` — Flux re-renders without these policies on next reconcile.

## Closes the netpol effort

After this:
- 7 namespaces locked down with Pattern A/B/C
- 2 chart-managed policies bug-fixed (keycloak postgres, oauth2-proxy redis)
- All Tier 1–3 apps from the STRIDE audit covered
- Tier 4 (kube-system, longhorn-system, metallb-system, ingress-nginx, cert-manager, actions-runner-system) deferred — separate effort
- arcanon (separate repo, manual deploy) deferred to its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)