### PR TITLE
security(netpol): Pattern A for actions-runner-system

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/controller-networkpolicy.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/controller-networkpolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: actions-runner-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: actions-runner-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: actions-runner-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring

--- a/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - runner-namespace.yaml
   - runner-networkpolicy.yaml
+  - controller-networkpolicy.yaml
   - operator-helmrelease.yaml
   - runner-scale-set-helmrelease.yaml
   - code-quality-runner-helmrelease.yaml


### PR DESCRIPTION
## Summary

Locks down the `actions-runner-system` namespace (ARC controller + per-runner-set listener pods). Companion to PR #17 which already covered `arc-runners` (the ephemeral runner pods themselves).

## Pattern A minus ingress-nginx

| Policy | Selects | Allows |
|---|---|---|
| `default-deny-ingress` | all pods | (bouncer at every door) |
| `allow-same-namespace` | all pods | from any pod in `actions-runner-system` (controller ↔ listener traffic) |
| `allow-monitoring` | all pods | from `monitoring` ns |

No public ingress allow because the namespace has no Services exposed publicly. The ARC controller and listeners poll GitHub outbound; nothing inbound from outside the namespace reaches them.

## Verified before submitting

- `kubectl get validatingwebhookconfigurations -o json | jq` → no webhooks point at this namespace, so no `ipBlock` API-server allow needed
- `kubectl get svc -n actions-runner-system` → empty, no public services

## Test plan

- [ ] All 3 policies present: `kubectl get netpol -n actions-runner-system`
- [ ] Controller pod healthy: `kubectl get pods -n actions-runner-system | grep gha-runner-scale-set-controller` → Running
- [ ] CI workflow can still spin up runners (runner-set listeners receive scale events from GitHub via outbound polling — netpol doesn't affect egress)
- [ ] Cross-ns deny test:
  ```bash
  kubectl run -n default --rm -i --restart=Never --image=alpine/curl netpol-test \
    --command -- sh -c "timeout 5 nc -zvw 3 actions-runner-system-gha-runner-scale-set-controller-gha.actions-runner-system.svc.cluster.local 443; echo EXIT=\$?"
  # expect: EXIT=1 (or "name does not resolve" if no service exists, also fine)
  ```

## Rollback

`git revert` — Flux re-renders without these policies on next reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)