### PR TITLE
security(pss): warn-mode labels on 7 namespaces (T3/E1/E3 diagnostic phase)

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/namespace.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   name: actions-runner-system
   labels:
     name: actions-runner-system
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-namespace.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   name: arc-runners
   labels:
     name: arc-runners
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/chromadb/namespace.yaml
+++ b/clusters/k3s-cluster/apps/chromadb/namespace.yaml
@@ -4,3 +4,10 @@ metadata:
   name: chromadb
   labels:
     name: chromadb
+    # Pod Security Standards — warn-only mode (diagnostic). Surfaces violations
+    # on `kubectl apply` and Flux reconcile. Does not enforce; existing pods are
+    # unaffected. Once warnings are clear, promote to `enforce`.
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/devpi/namespace.yaml
+++ b/clusters/k3s-cluster/apps/devpi/namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   name: devpi
   labels:
     name: devpi
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/harbor/namespace.yaml
+++ b/clusters/k3s-cluster/apps/harbor/namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   name: harbor
   labels:
     name: harbor
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/keycloak/namespace.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: keycloak
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/namespace.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest


### PR DESCRIPTION
## Summary

First step of the Pod Security Standards rollout (STRIDE T3/E1/E3). Adds **warn-only** labels to 7 namespaces — purely diagnostic, no enforcement. Surfaces which existing pods would fail the `restricted` profile.

## Labels added per namespace

```yaml
pod-security.kubernetes.io/warn: restricted
pod-security.kubernetes.io/warn-version: latest
pod-security.kubernetes.io/audit: restricted
pod-security.kubernetes.io/audit-version: latest
```

| Namespace | Why warn=restricted is the right starting probe |
|---|---|
| chromadb | single-pod app, runAsUser already set — likely fits restricted |
| devpi | runs as user 1000 — likely fits restricted |
| harbor | Bitnami chart with fsGroup heavy use — expect warnings, will downgrade to baseline if needed |
| keycloak | codecentric chart — expect warnings, evaluate after first deploy |
| monitoring | node-exporter is hostPath/hostPID — guaranteed warnings, used as confirmation that warn-mode catches real violations |
| actions-runner-system | ARC controller + listener pods, no host access — likely fits restricted |
| arc-runners | ephemeral runner pods, non-privileged — likely fits restricted |

## Why warn-only first

The original audit flagged `Pod Security Standards unenforced (17/20 namespaces)` as Critical. Going straight to `enforce=restricted` would block existing pod updates until every violation is fixed — an unbounded fix-it loop.

`warn` mode lets us:
1. Apply this PR with **zero behavioral risk** (existing pods keep running)
2. Observe which violations exist by watching `kubectl apply` output and Flux reconcile logs
3. Decide per-namespace whether to escalate to `restricted` or downgrade to `baseline` enforce

## Test plan

After merge:

- [ ] All 7 namespaces have the new labels:
  ```bash
  kubectl get ns chromadb devpi harbor keycloak monitoring actions-runner-system arc-runners \
    -o json | jq -r '.items[] | "\(.metadata.name): \(.metadata.labels | to_entries | map(select(.key | startswith("pod-security"))) | from_entries)"'
  ```
- [ ] Existing pods stay Running (no eviction)
- [ ] Force a redeploy of one workload to surface warnings:
  ```bash
  kubectl rollout restart -n chromadb deploy/chromadb
  # Look for: Warning: would violate PodSecurity "restricted:latest"
  ```
- [ ] Check audit log for violations (only relevant if K8s audit logging is enabled — currently it isn't, so audit label is a no-op until that's set up)

## Next steps after this PR

Based on warnings observed:
- Promote namespaces with no warnings to `enforce=restricted`
- Promote namespaces with manageable violations to `enforce=baseline`
- Document any namespace that genuinely needs to stay at warn-only (e.g., monitoring with node-exporter)

## Rollback

`git revert` — labels removed, no impact since nothing was being enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)