### PR TITLE
security(pss): Tier A — harden devpi (restricted) + chromadb (baseline)

### DIFF
--- a/clusters/k3s-cluster/apps/chromadb/deployment.yaml
+++ b/clusters/k3s-cluster/apps/chromadb/deployment.yaml
@@ -17,9 +17,21 @@ spec:
     spec:
       nodeSelector:
         node-role.apps: "true"
+      # Note: chromadb runs as root because the upstream chroma image lacks
+      # a USER directive and existing /data file permissions (mode 0644 on
+      # chroma.sqlite3) would prevent a non-root migration without manual
+      # chmod. Namespace is at PSS=baseline, not restricted, for this reason.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: chromadb
           image: chromadb/chroma:1.5.5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: IS_PERSISTENT
               value: "TRUE"

--- a/clusters/k3s-cluster/apps/chromadb/namespace.yaml
+++ b/clusters/k3s-cluster/apps/chromadb/namespace.yaml
@@ -4,9 +4,12 @@ metadata:
   name: chromadb
   labels:
     name: chromadb
-    # Pod Security Standards — warn-only mode (diagnostic). Surfaces violations
-    # on `kubectl apply` and Flux reconcile. Does not enforce; existing pods are
-    # unaffected. Once warnings are clear, promote to `enforce`.
+    # PSS enforce=baseline (not restricted) because the upstream chromadb image
+    # runs as root and the existing PVC's /data file permissions (mode 0644 on
+    # chroma.sqlite3) would prevent a clean non-root migration. Baseline still
+    # blocks privileged, hostPath, hostNetwork, hostPID, and hostIPC.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/audit: restricted

--- a/clusters/k3s-cluster/apps/devpi/deployment.yaml
+++ b/clusters/k3s-cluster/apps/devpi/deployment.yaml
@@ -18,12 +18,21 @@ spec:
       nodeSelector:
         node-role.apps: "true"
       securityContext:
+        runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: devpi-server
           image: harbor.theedgeworks.ai/base/devpi:v0.4.1
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: DEVPI_SERVERDIR
               value: /devpi/server

--- a/clusters/k3s-cluster/apps/devpi/namespace.yaml
+++ b/clusters/k3s-cluster/apps/devpi/namespace.yaml
@@ -4,6 +4,8 @@ metadata:
   name: devpi
   labels:
     name: devpi
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Summary

Tier A of the Pod Security Standards rollout — moves devpi and chromadb from warn-only to **enforce** mode after adding the missing securityContext fields the warn-mode probe surfaced.

## Changes

### devpi → `enforce=restricted`

Pod-level (added to existing `runAsUser: 1000, fsGroup: 1000`):
```yaml
runAsNonRoot: true
runAsGroup: 1000
seccompProfile:
  type: RuntimeDefault
```

Container-level (new):
```yaml
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
```

Namespace label change: adds `enforce=restricted/enforce-version=latest`.

### chromadb → `enforce=baseline` (NOT restricted)

The upstream `chromadb/chroma` image has no `USER` directive — defaults to root. Existing `/data/chroma.sqlite3` is mode `0644` (group can read but not write), so switching to `runAsUser: 1000` would break writes. Baseline is the right level here:

Pod-level (new):
```yaml
seccompProfile:
  type: RuntimeDefault
```

Container-level (new):
```yaml
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
```

Namespace label change: adds `enforce=baseline/enforce-version=latest`. Baseline still blocks privileged, hostPath, hostNetwork, hostPID, hostIPC — meaningful protection without forcing non-root.

## Test plan

- [ ] Flux reconciles without rejection (would reject only if violations remain):
  ```bash
  flux reconcile kustomization infra --with-source
  flux get kustomization infra
  ```
- [ ] devpi pod restarts and stays Running (runAsNonRoot enforcement on next deploy):
  ```bash
  kubectl get pod -n devpi
  curl -sI https://pypi.theedgeworks.ai
  ```
- [ ] chromadb pod restarts and stays Running:
  ```bash
  kubectl get pod -n chromadb
  curl -sI https://claudedb.theedgeworks.ai
  ```
- [ ] Verify enforcement is active:
  ```bash
  kubectl get ns devpi chromadb -o json | jq '.items[].metadata.labels' | grep enforce
  ```
- [ ] Try to deploy a violating pod (should be rejected):
  ```bash
  kubectl run -n devpi --image=alpine bad --command -- sleep 10
  # expect: PodSecurity violation, pod creation rejected
  ```

## Rollback

`git revert` — namespace drops to warn-only, deployments lose the securityContext (remain Running).

## Out of scope (Tier B/C follow-ups)

- harbor, keycloak, oauth2-proxy — Helm-managed, need value overrides per chart
- monitoring — node-exporter and OTel agent need hostPath/hostPID, can't reach restricted; will use baseline + per-workload exemptions later
- arc-runners, actions-runner-system — ARC chart value overrides
- chromadb non-root migration — separate PR with PVC chmod testing if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)