### PR TITLE
fix(flux-monitoring): correct job label and split absent alert per controller

### DIFF
--- a/clusters/k3s-cluster/apps/flux-monitoring/podmonitor.yaml
+++ b/clusters/k3s-cluster/apps/flux-monitoring/podmonitor.yaml
@@ -23,3 +23,9 @@ spec:
           - image-reflector-controller
   podMetricsEndpoints:
     - port: http-prom
+      # Override the Operator-default job label (`monitoring/flux-system`)
+      # with the controller name from the pod's `app` label, so alerts can
+      # match per-controller (helm-controller, source-controller, etc.).
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_label_app]
+          targetLabel: job

--- a/clusters/k3s-cluster/apps/flux-monitoring/prometheusrule.yaml
+++ b/clusters/k3s-cluster/apps/flux-monitoring/prometheusrule.yaml
@@ -10,16 +10,52 @@ spec:
   groups:
     - name: flux-system.rules
       rules:
-        - alert: FluxComponentAbsent
-          expr: |
-            absent(up{job=~"helm-controller|source-controller|kustomize-controller|notification-controller"} == 1)
+        # Per-controller absence alerts. The PodMonitor relabels `job` to the
+        # controller name (helm-controller, source-controller, etc.) so a single
+        # `absent()` per job catches a single-controller outage. A combined
+        # `job=~"a|b|c|d"` matcher would only fire when ALL four disappear.
+        - alert: FluxHelmControllerAbsent
+          expr: absent(up{job="helm-controller"} == 1)
           for: 5m
           labels:
             severity: critical
           annotations:
-            summary: Flux controller absent from Prometheus targets
+            summary: Flux helm-controller absent from Prometheus targets
             description: |
-              A Flux controller has been absent from Prometheus targets for >5m.
+              helm-controller has been absent from Prometheus targets for >5m.
+              Either Prometheus cannot scrape it, or the controller pod isn't running.
+
+        - alert: FluxSourceControllerAbsent
+          expr: absent(up{job="source-controller"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Flux source-controller absent from Prometheus targets
+            description: |
+              source-controller has been absent from Prometheus targets for >5m.
+              Either Prometheus cannot scrape it, or the controller pod isn't running.
+
+        - alert: FluxKustomizeControllerAbsent
+          expr: absent(up{job="kustomize-controller"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Flux kustomize-controller absent from Prometheus targets
+            description: |
+              kustomize-controller has been absent from Prometheus targets for >5m.
+              Either Prometheus cannot scrape it, or the controller pod isn't running.
+
+        - alert: FluxNotificationControllerAbsent
+          expr: absent(up{job="notification-controller"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Flux notification-controller absent from Prometheus targets
+            description: |
+              notification-controller has been absent from Prometheus targets for >5m.
               Either Prometheus cannot scrape it, or the controller pod isn't running.
 
         - alert: FluxReconciliationFailure


### PR DESCRIPTION
## Summary
- Fixes the perpetually-firing **FluxComponentAbsent** alert (active since 2026-04-26 19:48 — i.e. since the PodMonitor was deployed)
- Adds `job` relabeling on the PodMonitor so each Flux controller's metrics carry its name (`helm-controller`, `source-controller`, …)
- Splits the single combined `absent()` rule into 4 per-controller alerts so a single-controller outage actually fires

## Root cause
The alert expression in `prometheusrule.yaml` matches:
```
absent(up{job=~"helm-controller|source-controller|kustomize-controller|notification-controller"} == 1)
```
But the Prometheus Operator auto-derives `job=<podmonitor_namespace>/<podmonitor_name>` = `monitoring/flux-system`. The regex never matched any series, so `absent()` evaluated to 1 forever.

Verified with:
```
$ kubectl exec ... -- promtool query ... 'group by (job) (up{namespace="flux-system"})'
{job="monitoring/flux-system"}    # only one job; nothing matches the alert
```

## Why per-controller alerts
The original `absent(up{job=~"a|b|c|d"} == 1)` only fires when **all four** controllers disappear simultaneously, because `absent()` returns nothing as long as any matching series exists. Per-controller alerts (`absent(up{job="helm-controller"})`, etc.) catch a single-controller outage.

## Test plan
- [ ] After Flux reconciles, `kubectl get podmonitor -n monitoring flux-system -o yaml` shows the relabeling rule
- [ ] `group by (job) (up{namespace="flux-system"})` in Prometheus shows 4 distinct jobs (helm-controller, source-controller, kustomize-controller, notification-controller)
- [ ] FluxComponentAbsent alert disappears (replaced by 4 named ones, all in inactive state)
- [ ] All 4 new alerts (`FluxHelmControllerAbsent`, etc.) show `state=inactive` since all controllers are up