### PR TITLE
security(harbor): enforce restricted PSS, harden standalone redis

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/namespace.yaml
+++ b/clusters/k3s-cluster/apps/harbor/namespace.yaml
@@ -4,6 +4,8 @@ metadata:
   name: harbor
   labels:
     name: harbor
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/audit: restricted

--- a/clusters/k3s-cluster/apps/harbor/redis.yaml
+++ b/clusters/k3s-cluster/apps/harbor/redis.yaml
@@ -28,6 +28,13 @@ spec:
     spec:
       nodeSelector:
         node-role.apps: "true"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: redis
         image: redis:8-alpine
@@ -43,6 +50,11 @@ spec:
           limits:
             memory: 128Mi
             cpu: 100m
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       volumes:
       - name: redis-storage
         persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- Promote the `harbor` namespace from warn-only to `enforce=restricted`
- Add pod + container `securityContext` to the standalone `redis` deployment so it passes restricted admission

## Discovery — what's already compliant
The 7 Goharbor chart pods are **already restricted-compliant** out of the box from chart 1.18.1:

| Pod | runAsNonRoot | allowPrivEsc=false | drop[ALL] | seccomp=RuntimeDefault |
|---|---|---|---|---|
| harbor-core | ✅ | ✅ | ✅ | ✅ |
| harbor-portal | ✅ | ✅ | ✅ | ✅ |
| harbor-jobservice | ✅ | ✅ | ✅ | ✅ |
| harbor-registry (2 containers) | ✅ | ✅ | ✅ | ✅ |
| harbor-trivy | ✅ | ✅ | ✅ | ✅ |
| harbor-exporter | ✅ | ✅ | ✅ | ✅ |
| harbor-database | ✅ | ✅ | ✅ | ✅ |

→ **No HelmRelease values change needed for the chart pods.**

## What's not compliant
The standalone `redis.yaml` deployment had no securityContext at all. Server-side dry-run flagged 4 violations:
```
allowPrivilegeEscalation != false
unrestricted capabilities (must drop ALL)
runAsNonRoot != true
seccompProfile (must set type=RuntimeDefault)
```

This PR adds:
- pod-level: `runAsNonRoot:true`, `runAsUser/Group/fsGroup:999` (redis image's default user), `seccompProfile.type:RuntimeDefault`
- container-level: `allowPrivilegeEscalation:false`, `capabilities.drop:[ALL]`

## Validation
```
$ kubectl apply --dry-run=server -f redis.yaml
deployment.apps/redis configured (server dry run)   # no PSS warnings

$ kubectl apply --dry-run=server -f namespace.yaml
namespace/harbor configured (server dry run)
# warning is for the EXISTING running redis pod — replaced by rollout once
# the new deployment template lands
```

All 7 chart-managed deployments dry-run clean as well (verified individually).

## Test plan
- [ ] After Flux reconcile, `kubectl get pod -n harbor` shows redis pod is recreated with `securityContext` populated
- [ ] All 7 harbor pods stay running (no admission failures on subsequent restarts)
- [ ] `kubectl get ns harbor -o yaml | grep enforce` shows `pod-security.kubernetes.io/enforce: restricted`
- [ ] Container registry still functions: `podman login harbor.theedgeworks.ai` → `podman pull harbor.theedgeworks.ai/library/<image>`
- [ ] Harbor UI loads at https://harbor.theedgeworks.ai

## Rollback
If anything fails: revert this PR. The redis Deployment template change triggers a rollout, but the old ReplicaSet remains and a revert restores the old pod.