### PR TITLE
fix(harbor/redis): Recreate strategy + image-aligned GID + OnRootMismatch fsGroup

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/redis.yaml
+++ b/clusters/k3s-cluster/apps/harbor/redis.yaml
@@ -18,6 +18,12 @@ metadata:
   namespace: harbor
 spec:
   replicas: 1
+  # PVC is ReadWriteOnce, so a RollingUpdate cannot start a new pod until the
+  # old one releases the volume — and the old one won't terminate until the
+  # new one is Ready. That deadlocks any template change. Recreate kills the
+  # old pod first (~10s redis unavailability per update; harbor retries).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: redis

--- a/clusters/k3s-cluster/apps/harbor/redis.yaml
+++ b/clusters/k3s-cluster/apps/harbor/redis.yaml
@@ -36,9 +36,15 @@ spec:
         node-role.apps: "true"
       securityContext:
         runAsNonRoot: true
+        # Image redis:8-alpine: uid=999(redis) gid=1000(redis). Matching
+        # runAsGroup avoids gid=999 surfacing as `ping` in the running pod.
         runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        # Skip recursive chown on every restart once /data root is correctly
+        # owned. First rollout after this change does a one-time chown
+        # 999→1000 on the existing PVC; subsequent restarts are fast.
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary
Three related redis-Deployment fixes bundled together:

1. **`strategy: Recreate`** — fixes the PVC multi-attach deadlock that surfaced when PR #26 rolled out (RWO PVC + RollingUpdate cannot make progress)
2. **`runAsGroup: 1000`** (was 999) — matches the redis:8-alpine image's actual `gid=1000(redis)`. The previous value made the running pod show `gid=999(ping)`, which works (fsGroup forces correct supplementary group) but is misleading
3. **`fsGroupChangePolicy: OnRootMismatch`** (new) — skips the recursive chown of `/data` on every pod start once the root is correctly owned. Default 'Always' policy is wasteful; chart-managed harbor uses OnRootMismatch for the same reason (helmrelease.yaml jobservice/registry blocks)

## Why bundle
All three relate to the redis Deployment hygiene issues uncovered while landing PR #26. Doing them in a single PR avoids 3 separate redis rollouts (each ~10s of redis-cache miss).

## How #1 surfaced
After PR #26 merged, the new redis pod sat in `ContainerCreating` with:
```
FailedAttachVolume: Multi-Attach error for volume "pvc-..."
Volume is already used by pod(s) redis-7755b5db96-tvj6t
```
RWO PVC + RollingUpdate ⇒ deadlock (new pod can't mount until old releases; old won't terminate until new is Ready). Resolved manually with `kubectl delete pod`.

## Impact on apply
- One rollout (Recreate-style — old pod terminates first)
- ~10s redis unavailability; harbor retries
- One-time fsGroup recursive chown 999→1000 on the existing PVC (~1Gi, small files, cheap)
- After this rollout: future redis-template changes complete cleanly without manual intervention, and restarts skip the chown

## Test plan
- [ ] Flux applies, old pod terminates, new pod mounts PVC and starts
- [ ] `kubectl exec ... -- id` shows `uid=999(redis) gid=1000(redis)`
- [ ] `kubectl get deploy -n harbor redis -o yaml` shows `strategy.type: Recreate` and `fsGroupChangePolicy: OnRootMismatch`
- [ ] `kubectl exec ... -- redis-cli ping` returns PONG
- [ ] Harbor still reachable at `https://harbor.theedgeworks.ai`