### PR TITLE
security(keycloak): enforce restricted PSS, harden keycloakx pod template

### DIFF
--- a/clusters/k3s-cluster/apps/keycloak/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/helmrelease.yaml
@@ -57,6 +57,28 @@ spec:
       - name: JAVA_OPTS_APPEND
         value: "-XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError -Djava.awt.headless=true -Djgroups.dns.query=keycloak-keycloak-keycloakx-headless.keycloak.svc.cluster.local"
 
+    # PSS=restricted compliance.
+    # Pod-level: fsGroup so /opt/keycloak/data is writable; seccompProfile set
+    # at pod level so it inherits to all containers (including init).
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+      seccompProfile:
+        type: RuntimeDefault
+    # Keycloak container — chart defaults set runAsUser/runAsNonRoot but not
+    # caps/allowPrivEsc/seccomp. We restate the defaults explicitly + add the
+    # restricted-PSS-required fields.
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
     # Database connection checker
     dbchecker:
       enabled: true
@@ -68,6 +90,11 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       resources:
         requests:
           cpu: 20m

--- a/clusters/k3s-cluster/apps/keycloak/namespace.yaml
+++ b/clusters/k3s-cluster/apps/keycloak/namespace.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   name: keycloak
   labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Summary
- Promote `keycloak` namespace from warn-only to **`enforce=restricted`**
- Add the missing securityContext fields to the keycloakx HelmRelease so the rendered StatefulSet passes restricted admission

## Discovery — what's already compliant

| Pod | Issues under restricted |
|---|---|
| `keycloak-postgresql-0` (bitnami) | None — chart sets all required fields |
| `keycloak-keycloak-keycloakx-0` (codecentric) | 3 violations: `allowPrivilegeEscalation`, `capabilities.drop=[ALL]`, `seccompProfile` |

The codecentric/keycloakx 7.1.5 chart only sets `runAsUser`/`runAsNonRoot` on the container and `fsGroup` on the pod — the rest of the restricted-PSS fields aren't templated unless you supply them via values.

## Chart value paths
| Value path | Effect |
|---|---|
| `podSecurityContext` | pod-level (chart default has only `fsGroup:1000`) |
| `securityContext` | keycloak container (chart default has only `runAsUser:1000`, `runAsNonRoot:true`) |
| `dbchecker.securityContext` | dbchecker init container (already overridden in this HelmRelease) |

## Validation
Rendered the chart with the new values via `helm template`, then dry-ran the rendered StatefulSet against a **temporary namespace labeled `enforce=restricted`**. The StatefulSet was admitted cleanly with no PSS warnings.

Rendered securityContexts (verified):
- pod: `{fsGroup:1000, fsGroupChangePolicy:OnRootMismatch, seccompProfile:RuntimeDefault}`
- dbchecker init: `{allowPrivilegeEscalation:false, capabilities.drop:[ALL], runAsGroup:1000, runAsNonRoot:true, runAsUser:1000, seccompProfile:RuntimeDefault}`
- keycloak container: `{allowPrivilegeEscalation:false, capabilities.drop:[ALL], runAsGroup:1000, runAsNonRoot:true, runAsUser:1000, seccompProfile:RuntimeDefault}`

## Impact on apply
- Flux re-renders the keycloakx chart with the new values → StatefulSet pod template changes → RollingUpdate triggered
- Old keycloakx pod terminates, new pod starts with hardened securityContext
- ~30s `auth.theedgeworks.ai` unavailability during the pod swap (callers retry: harbor, monitoring, arcanon)
- postgres pod untouched (already compliant; no chart values change)

## Test plan
- [ ] After Flux reconcile, `kubectl get ns keycloak -o yaml | grep enforce` shows `pod-security.kubernetes.io/enforce: restricted`
- [ ] `kubectl get pod -n keycloak keycloak-keycloak-keycloakx-0 -o jsonpath='{.spec.containers[0].securityContext}'` shows the full restricted-compliant block
- [ ] `curl -sI https://auth.theedgeworks.ai` returns 200 (or 302 to login)
- [ ] Harbor login flow works (`https://harbor.theedgeworks.ai` → "Login with OIDC" → keycloak → back to harbor)
- [ ] Monitoring login flow works (Grafana → keycloak → Grafana)

## Rollback
Revert this PR — old StatefulSet template (without the extra securityContext fields) re-renders, and namespace falls back to warn-only. Note: with `enforce=restricted` removed, the running pod's securityContext can be relaxed, but it's already rolled out, so a revert just lets the next rollout happen without those constraints.