### PR TITLE
security(actions-runner-system): enforce restricted PSS

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 10
     
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 6
     
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/namespace.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/namespace.yaml
@@ -4,6 +4,8 @@ metadata:
   name: actions-runner-system
   labels:
     name: actions-runner-system
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/audit: restricted

--- a/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 6
     
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/operator-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/operator-helmrelease.yaml
@@ -24,12 +24,30 @@ spec:
     remediation:
       retries: 3
   values:
-    # Controller configuration
-    controllerManager:
-      resources:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "256Mi"
-          cpu: "200m"
+    # Resource limits for the controller manager.
+    # Note: must be top-level (not nested under `controllerManager:` as
+    # before — the chart's deployment template references .Values.resources
+    # directly, so the previous nested form was silently ignored, leaving
+    # the controller with no resource limits).
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+    # PSS=restricted compliance for the controller pod.
+    # runAsUser intentionally omitted — let k8s use the image's USER
+    # directive; runAsNonRoot:true rejects only if image USER is 0.
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true

--- a/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 3
 
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 1
 
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
@@ -33,6 +33,26 @@ spec:
     minRunners: 0
     maxRunners: 10
     
+    # Listener pod template (proxy that polls GitHub API for jobs and
+    # spawns runners). The listener image is the same distroless controller
+    # image, which runs as nonroot via its USER directive; we add the
+    # caps/seccomp/allowPrivEsc fields needed for restricted PSS.
+    listenerTemplate:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: listener
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+
     # Runner pod template
     template:
       spec:


### PR DESCRIPTION
## Summary
Promote `actions-runner-system` from warn-only to **`enforce=restricted`**. Hardens the controller (1 pod) and the 6 listener pods (one per AutoscalingRunnerSet).

## What's in scope vs. deferred
| Workload | Namespace | This PR? |
|---|---|---|
| gha-runner-scale-set-controller | actions-runner-system | ✅ |
| 6 listener pods (one per runner set) | actions-runner-system | ✅ |
| Dynamic runner pods (running CI jobs) | **arc-runners** | ❌ deferred — runner pods use podman; restricted PSS may break image builds. Namespace stays warn-only until runtime-validated. |

## Pre-existing bug fix
`operator-helmrelease.yaml` had `resources:` nested under `controllerManager:`, but the chart's deployment template references `.Values.resources` directly (top-level). The nested form was silently ignored, leaving the controller running with `resources: {}` (no limits). This PR fixes that as a side-effect — resources now actually apply.

Verified the bug existed:
```
$ kubectl get pod -n actions-runner-system <controller> -o jsonpath='{.spec.containers[0].resources}'
{}
```

## Changes
- `operator-helmrelease.yaml`:
  - `resources:` moved to top-level (fixes silent-ignore bug)
  - Added top-level `podSecurityContext` + `securityContext` (PSS=restricted)
- 6 runner-set HelmReleases: added `listenerTemplate.spec.securityContext` (pod + container) so the auto-spawned AutoscalingListener pods carry the right fields
- `namespace.yaml`: `enforce=restricted`

## securityContext rationale
- `runAsUser` intentionally **omitted** — chart image is distroless and ships with a non-root USER directive. `runAsNonRoot:true` rejects only if the image USER is 0. Avoids hardcoding a UID that could drift across chart upgrades.
- `readOnlyRootFilesystem:true` set on both controller and listener — both are simple Go binaries that don't write to /. Validated by inspecting current volumes (only secrets, configMaps, projected, downwardAPI; all read-only).
- `seccompProfile:RuntimeDefault` set at pod level so it inherits to all containers.

## Validation
- `helm template` rendered all 7 workloads (controller + 6 runner-set listenerTemplates) with the new values
- Synthesized each rendered pod into a temp namespace labeled `enforce=restricted` and ran `kubectl apply --dry-run=server`
- All 7 admitted cleanly with zero PSS violations

## Impact on apply
- Controller pod: rolling update by Deployment controller — new pod created with new securityContext, old pod terminated when ready
- 6 listener pods: AutoscalingListener controller detects the listenerTemplate change, terminates old listener pods, spawns new ones with new securityContext
- ~30s gap per listener while it's being recreated (job polling pauses; queued jobs wait, no jobs lost)
- Runner pods in `arc-runners` namespace: **unaffected** — that namespace stays warn-only, dynamic runner pods continue to spawn as before

## Test plan
- [ ] After Flux reconcile, controller pod `kubectl describe` shows new resources + securityContext
- [ ] All 6 listener pods recreated with `runAsNonRoot:true`, `allowPrivEsc:false`, `caps drop ALL`, `seccomp:RuntimeDefault`
- [ ] Trigger a small CI workflow on each runner set — runner pods spawn in arc-runners, complete the job, terminate
- [ ] No `policy.kubernetes.io/audit-violations` events in actions-runner-system

## Rollback
Revert the PR. Controller/listeners get re-rolled with old (empty) securityContext; namespace falls back to warn-only.