### PR TITLE
security(monitoring): clean up audit-mode PSS warnings on grafana + loki

### DIFF
--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
@@ -53,6 +53,13 @@ spec:
         storageClassName: longhorn
         accessModes: ["ReadWriteOnce"]
         size: 2Gi
+
+      # Skip the init-chown-data init container — it runs as UID 0 with
+      # cap_chown to fix volume permissions, which violates restricted PSS.
+      # The pod-level fsGroup:472 already ensures kubelet recursively
+      # chowns the PVC to GID 472 on mount, so the init is redundant.
+      initChownData:
+        enabled: false
       # Ensure admin password is set or use default (prom-operator)
       adminPassword: "prom-operator"
 

--- a/clusters/k3s-cluster/apps/loki/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/loki/helmrelease.yaml
@@ -25,6 +25,18 @@ spec:
 
     loki:
       auth_enabled: false
+      # PSS=restricted compliance: chart defaults set everything except
+      # seccompProfile. Adding it here merges into the chart's existing
+      # podSecurityContext / containerSecurityContext maps (which already
+      # set runAs*, fsGroup, drop ALL, allowPrivEsc=false, readOnlyRootFs).
+      # Applies to both the loki StatefulSet and lokiCanary DaemonSet
+      # (the canary template references loki.podSecurityContext).
+      podSecurityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        seccompProfile:
+          type: RuntimeDefault
       commonConfig:
         replication_factor: 1
       storage:


### PR DESCRIPTION
## Summary
Silences avoidable PSS-restricted audit warnings on grafana, loki, and loki-canary by adjusting Helm values. Namespace stays **warn-only** because node-exporter and otel-collector-agent need hostNetwork/hostPID/hostPort and cannot run under restricted.

## Why monitoring stays warn-only
Pod-by-pod audit:
| Pod | Compliant? | Notes |
|---|---|---|
| alertmanager, prometheus, kube-state-metrics, operator | ✅ | chart defaults compliant |
| **node-exporter** (DaemonSet) | ❌ inherent | hostNetwork=true, hostPID=true, hostPort 9100 |
| **otel-collector-agent** (DaemonSet) | ❌ inherent | hostPorts 14250/14268/4317/4318/6831/9411 |
| grafana | ❌ avoidable | init-chown-data runs as UID 0 with cap_chown |
| loki, loki-canary | ❌ avoidable | missing seccompProfile only |

Promoting the namespace to enforce=restricted would block node-exporter and otel-agent — both inherent host-level monitoring requirements. Audit cleanup still has value: real future violations no longer hide behind chart noise.

## Changes
- **grafana** (`kube-prometheus-stack/helmrelease.yaml`): `grafana.initChownData.enabled: false`. The init container exists to chown the PVC to GID 472, but pod-level `fsGroup:472` already triggers a recursive chown on mount — the init is redundant and runs as UID 0.
- **loki** (`loki/helmrelease.yaml`): add `seccompProfile:RuntimeDefault` at `loki.podSecurityContext` and `loki.containerSecurityContext`. Helm merges into chart defaults (which already set runAs*, fsGroup, drop ALL, allowPrivEsc=false, readOnlyRootFs). Both StatefulSet and DaemonSet (canary) pick it up because the canary template references the same value paths.

## Validation
Rendered each chart with the new values, then dry-ran the rendered StatefulSet/Deployment/DaemonSet against a temp namespace labeled `enforce=restricted`. All three admitted cleanly:
```
deployment.apps/kps-grafana created (server dry run)
statefulset.apps/loki created (server dry run)
daemonset.apps/loki-canary created (server dry run)
```

## Impact on apply
- Grafana: rolling update creates new pod without init container — ~30s downtime via Recreate strategy (already configured for RWO PVC). No data loss; PVC retained.
- Loki: rolling update on the StatefulSet — ~30s downtime; existing log data on PVC unchanged.
- Loki-canary: DaemonSet rolling update — one pod per node restarted in sequence.

## Test plan
- [ ] After Flux reconcile, grafana pod has 0 init containers
- [ ] `kubectl get events -n monitoring --field-selector reason=FailedCreate | grep restricted` returns nothing for grafana/loki/loki-canary in the audit log
- [ ] Grafana UI loads at `https://monitor.theedgeworks.ai`
- [ ] Loki queries return data from a Grafana panel