### PR TITLE
limits(arc-listeners): add resource requests/limits to listener pods

### DIFF
--- a/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/code-quality-runner-helmrelease.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/modbus-runner-set.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/opcua-runner-set.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/os-builder-runner-set.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/renovate-runner-set.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:

--- a/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/actions-runner-controller/runner-scale-set-helmrelease.yaml
@@ -52,6 +52,17 @@ spec:
                   - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+            # Listener is a small Go binary that polls the GitHub API.
+            # 25m/64Mi is enough idle; bursts to ~50m/100Mi when starting
+            # runner pods. Cap at 100m/128Mi so a runaway can't starve
+            # neighbors.
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
 
     # Runner pod template
     template:


### PR DESCRIPTION
## Summary
Closes one slice of STRIDE finding **D1** (resource limits missing cluster-wide).

The 6 listener pods (one per AutoscalingRunnerSet) had **no** resource requests or limits — the listenerTemplate added in PR #29 set securityContext only. This PR adds resources via the existing `listenerTemplate` block in each runner-set HelmRelease.

## Sizing rationale
| Field | Value | Why |
|---|---|---|
| requests.cpu | 25m | Idle steady state |
| requests.memory | 64Mi | Listener is a small Go binary; observed RSS ~30Mi |
| limits.cpu | 100m | Bursts when spawning runners (~50m peak) |
| limits.memory | 128Mi | 2x the observed peak; OOM unlikely |

## Validation
Rendered each runner-set chart with the new values and confirmed all 6 AutoscalingRunnerSets carry the listener resources block.

## Impact on apply
- Each AutoscalingListener resource updates → controller terminates and respawns the listener pod with the new resources
- ~30s gap per listener while it restarts (job polling pauses; queued jobs wait, no jobs lost)
- 6 brief restarts staggered as Flux applies the changes

## Test plan
- [ ] After Flux reconcile, all 6 listener pods have non-empty `resources` (`kubectl get pod ... -o jsonpath='{.spec.containers[0].resources}'`)
- [ ] Trigger a small CI workflow on each runner set — listener picks up the job, spawns a runner, runner completes
- [ ] No new OOM events in actions-runner-system (`kubectl get events -n actions-runner-system --field-selector reason=OOMKilling`)