### PR TITLE
limits(harbor): add resources to core/portal/jobservice/registry

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
@@ -33,6 +33,15 @@ spec:
       image:
         repository: ghcr.io/octohelm/harbor/harbor-core
         tag: v2.14.0
+      # Idle ~1m/70Mi; spikes during auth/scan triggers. Headroom for
+      # OIDC token validation under burst (multiple users login).
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
 
     portal:
       nodeSelector:
@@ -40,6 +49,14 @@ spec:
       image:
         repository: ghcr.io/octohelm/harbor/harbor-portal
         tag: v2.14.0
+      # Static nginx serving the UI bundle. Idle ~1m/7Mi.
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
     jobservice:
       nodeSelector:
         node-role.apps: "true"
@@ -52,6 +69,14 @@ spec:
         runAsGroup: 10000
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
+      # Idle ~2m/34Mi; spikes during GC and replication runs.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
     registry:
       nodeSelector:
         node-role.apps: "true"
@@ -69,10 +94,27 @@ spec:
           fsGroupChangePolicy: OnRootMismatch
         # Override registry config to use /var/lib/registry as storage path
         # This matches the default registry image volume path
+        # Idle ~1m/55Mi; image push/pull streams ~200Mi peak. Generous
+        # limit to avoid OOM during big-image (>1GB) pushes from CI.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1
+            memory: 1Gi
       controller:
         image:
           repository: ghcr.io/octohelm/harbor/harbor-registryctl
           tag: v2.14.0
+        # Sidecar control plane — small Go binary. Modest sizing.
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
     nginx:
       nodeSelector:
         node-role.apps: "true"


### PR DESCRIPTION
## Summary
Adds resource requests/limits to the 5 harbor chart components that lacked them: **core, portal, jobservice, registry, registryctl**. Existing resources on database/exporter/trivy untouched.

## Sizing rationale (from observed `kubectl top`)
| Component | Idle | Request | Limit | Why |
|---|---|---|---|---|
| core | 1m / 70Mi | 50m / 128Mi | 500m / 512Mi | OIDC token validation, DB queries, multi-user login burst |
| portal | 1m / 7Mi | 10m / 32Mi | 100m / 128Mi | Static nginx serving the UI bundle |
| jobservice | 2m / 34Mi | 50m / 128Mi | 500m / 512Mi | GC/replication runs spike CPU |
| registry | 1m / 55Mi | 100m / 256Mi | **1 / 1Gi** | Streams big-image (>1GB) pushes from CI without OOM |
| registryctl | small | 25m / 64Mi | 100m / 128Mi | Sidecar control plane |

Limits are deliberately generous; the goal is "no runaway can starve the node" rather than tight packing. Registry is the most generous because we've seen >200Mi RSS during CI pushes and want headroom.

## Validation
Rendered the chart with the new values — all 5 components carry their resource blocks. Existing components (database, exporter, trivy) unchanged.

## Impact on apply
- Each component triggers a Deployment rolling update — new pod with resources, old pod terminated when ready
- ~30s downtime per component (sequenced; total ~2-3 min during rollout)
- Harbor registry availability dips briefly per restart; CI pulls/pushes retry transparently

## Test plan
- [ ] After Flux reconcile, `kubectl describe pod -n harbor` for each of the 5 shows non-empty `Resources:`
- [ ] `https://harbor.theedgeworks.ai` UI loads (portal)
- [ ] `podman login harbor.theedgeworks.ai` + `podman pull <existing-image>` works (registry + core)
- [ ] No OOMKilled events: `kubectl get events -n harbor --field-selector reason=OOMKilling`