### PR TITLE
fix(harbor): use Recreate strategy for jobservice + registry (RWO PVCs)

### DIFF
--- a/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/harbor/helmrelease.yaml
@@ -24,7 +24,17 @@ spec:
   values:
     externalURL: https://harbor.theedgeworks.ai
     imagePullPolicy: IfNotPresent
-    
+
+    # Use Recreate for the jobservice and registry deployments because their
+    # PVCs are RWO (longhorn). RollingUpdate (the chart default) deadlocks on
+    # any template change: new pod can't mount the volume until the old pod
+    # releases it, and the old pod won't terminate until the new pod is Ready.
+    # Surfaced when PR #32 (resource limits) triggered rollouts that hung in
+    # ContainerCreating with FailedAttachVolume / Multi-Attach errors.
+    # Costs ~30s downtime per redeploy; harbor clients retry transparently.
+    updateStrategy:
+      type: Recreate
+
     # Harbor Core Configuration
     # Using octohelm/harbor images from GHCR which support ARM64
     core:


### PR DESCRIPTION
## Summary
Same RWO/RollingUpdate deadlock as PR #27 (redis), now hit in harbor's jobservice and registry deployments after PR #32's resource limits triggered rollouts.

The Goharbor chart exposes a top-level `updateStrategy.type` that's wired to both jobservice and registry deployments (the only Deployments with PVCs in the chart — database/trivy are StatefulSets). Setting it to `Recreate` is the chart-recommended fix for clusters without RWM (we only have RWO via longhorn).

## How it surfaced
After PR #32 merged, both new pods sat in `ContainerCreating` for >4 minutes:
```
FailedAttachVolume: Multi-Attach error for volume "pvc-..."
Volume is already used by pod(s) harbor-harbor-jobservice-675554649b-755pv
```
Resolved manually with `kubectl delete pod` to release the PVCs.

## Why pre-patch is required
Per memory note `feedback_ssa_strategy_field_removal.md`: when the live Deployment has `spec.strategy.rollingUpdate: {...}` set by an earlier `kubectl apply`, Flux's SSA can't drop it just because the new manifest doesn't mention it (different field manager owns it). The merged result has both `type: Recreate` AND `rollingUpdate: {...}`, which the API rejects.

I pre-patched both live deployments before pushing this PR:
```
kubectl patch deployment -n harbor <name> --type=strategic \
  -p '{"spec":{"strategy":{"$retainKeys":["type"],"type":"Recreate"}}}'
```
Verified: both now show `{"type":"Recreate"}` with no orphan rollingUpdate field.

## Impact on apply
- No additional rollout — `spec.strategy` change in Flux SSA is a no-op now that the live state already matches
- Future redeploys (resource bumps, image bumps, securityContext changes) will use Recreate: ~30s pod-gap, harbor clients retry

## Test plan
- [ ] `flux reconcile helmrelease harbor` succeeds (READY=True, no SSA errors)
- [ ] `kubectl get deploy -n harbor harbor-harbor-jobservice -o jsonpath='{.spec.strategy}'` returns `{"type":"Recreate"}`
- [ ] Same for registry
- [ ] Next time someone bumps an image or tweaks resources, the rollout completes without manual unstick