### PR TITLE
limits(monitoring/kps): add resources for grafana, prometheus, ks-metrics, etc

### DIFF
--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
@@ -36,6 +36,17 @@ spec:
         # Retention configuration
         retention: 10d
         retentionSize: 450GB
+        # Observed ~173m/1.3Gi at steady state. Generous headroom because
+        # query bursts (Grafana dashboard refreshes) can spike CPU; 10d
+        # of metrics means TSDB head can grow during high-cardinality
+        # spikes. OOM here would lose recent samples.
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
         # Scrape ServiceMonitors from all namespaces
         serviceMonitorSelectorNilUsesHelmValues: false
         podMonitorSelectorNilUsesHelmValues: false
@@ -60,6 +71,26 @@ spec:
       # chowns the PVC to GID 472 on mount, so the init is redundant.
       initChownData:
         enabled: false
+
+      # Observed RSS ~900Mi (dashboard + query result caches accumulate).
+      # 2Gi limit gives 2x headroom; OOM was a real risk at 1Gi.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 500m
+          memory: 2Gi
+      # sc-dashboard and sc-datasources sidecars use the shared sidecar
+      # value path. Both are tiny (Python file watchers).
+      sidecar:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 50m
+            memory: 64Mi
       # Ensure admin password is set or use default (prom-operator)
       adminPassword: "prom-operator"
 
@@ -204,8 +235,10 @@ spec:
         # available at /etc/alertmanager/secrets/grafana-smtp/GF_SMTP_PASSWORD
         secrets:
           - grafana-smtp
+        # Idle ~1m/46Mi for the alertmanager container.
         resources:
           limits:
+            cpu: 100m
             memory: 256Mi
           requests:
             cpu: 50m
@@ -283,9 +316,43 @@ spec:
 
     # Resource limits can be tuned for RPi
     prometheusOperator:
+      # Idle ~2m/49Mi.
       resources:
         limits:
+          cpu: 200m
           memory: 200Mi
         requests:
           cpu: 100m
           memory: 100Mi
+      # config-reloader sidecar runs in BOTH alertmanager and prometheus
+      # StatefulSets. Single value path covers both. Idle ~1m/15Mi each.
+      prometheusConfigReloader:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 50m
+            memory: 64Mi
+
+    # Subchart values (resources flow into the kube-state-metrics
+    # Deployment via the bundled subchart).
+    # Idle ~2m/43Mi.
+    kube-state-metrics:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+
+    # node-exporter DaemonSet — one pod per node. Idle 1-4m/12-24Mi.
+    prometheus-node-exporter:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi


### PR DESCRIPTION
## Summary
Adds resource requests/limits to the 8 kube-prometheus-stack workloads that were running unbounded. Closes the kps slice of STRIDE D1.

| component | request | limit | Sizing source |
|---|---|---|---|
| **grafana** | 100m / 512Mi | 500m / 2Gi | observed RSS ~906Mi (dashboard query caches) |
| grafana sc-dashboard | 10m / 32Mi | 50m / 64Mi | tiny Python file watcher |
| grafana sc-datasources | 10m / 32Mi | 50m / 64Mi | tiny Python file watcher |
| **prometheus** | 200m / 1Gi | 1 / 2Gi | observed 173m / 1.3Gi (10d retention) |
| alertmanager | 50m / 128Mi | 100m / 256Mi | only `limits.cpu` was missing — now added |
| config-reloader (×2) | 10m / 32Mi | 50m / 64Mi | shared sidecar in both AM + Prom StatefulSets |
| kube-state-metrics | 25m / 64Mi | 100m / 128Mi | observed 2m / 43Mi |
| node-exporter (×5) | 25m / 32Mi | 100m / 64Mi | observed 1-4m / 12-24Mi per node |
| prometheusOperator | 100m / 100Mi | 200m / 200Mi | only `limits.cpu` was missing — now added |

## Why these limits in particular
- **grafana 2Gi**: observed RSS is 906Mi and growing slowly as dashboards are loaded. A 1Gi limit would OOM-kill within hours. 2Gi gives 2× headroom.
- **prometheus 2Gi**: TSDB head can balloon during high-cardinality scrape spikes. 10d/450GB retention is large enough that head growth matters.
- **node-exporter 64Mi**: tight but realistic — observed peak 24Mi.
- **All limits**: deliberately on the generous side. The goal is "no runaway can starve a node," not tight packing. Memory is the binding resource on the rpis.

## How config-reloader gets its values
The chart exposes a single `prometheusOperator.prometheusConfigReloader.resources` value. The operator passes this to the Alertmanager and Prometheus controllers via command-line flags (`--config-reloader-cpu-limit=50m`, etc.) and the operator templates the StatefulSets accordingly. Verified in the rendered operator deployment.

## Validation
- Rendered the chart with the new values
- Inspected each Deployment/StatefulSet/DaemonSet — all containers have non-empty resources
- Inspected the Prometheus and Alertmanager CRs — both have `spec.resources` with the new values (operator templates the StatefulSets at runtime)
- Inspected the operator deployment — `--config-reloader-cpu-limit=50m`, `--config-reloader-memory-limit=64Mi`, etc. command-line args present

## Impact on apply
- Each affected workload triggers a Deployment/StatefulSet/DaemonSet rolling update — new pod with resources, old pod terminated when ready
- ~30s gap per workload (sequenced; total ~3-5 min during rollout)
- Grafana uses Recreate strategy (RWO PVC) — single ~30s gap
- Prometheus is the biggest pod by memory; the new 2Gi limit gives more headroom than the unbounded current state would in the steady case (kubelet would have evicted on memory pressure if the node was tight)

## Test plan
- [ ] After Flux reconcile, all listed pods show non-empty `resources`
- [ ] Grafana UI still loads (https://monitor.theedgeworks.ai)
- [ ] Prometheus query still returns data: `kubectl exec -n monitoring prometheus-... -c prometheus -- wget -qO- 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result | length'`
- [ ] Alertmanager UI accessible
- [ ] No OOM events: `kubectl get events -n monitoring --field-selector reason=OOMKilling`
- [ ] Critical alert path still works (severity=critical → email)

## Remaining D1 slices in monitoring
After this merges, two more workloads need resources:
- **loki + loki-canary** (different chart, separate PR)
- **opentelemetry-collector-agent** (different chart, separate PR)