### PR TITLE
limits(monitoring/loki): add resources for loki-sc-rules + lokiCanary

### DIFF
--- a/clusters/k3s-cluster/apps/loki/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/loki/helmrelease.yaml
@@ -56,8 +56,12 @@ spec:
     # Single binary configuration
     singleBinary:
       replicas: 1
+      # Idle ~50m/350Mi. Memory limit was 1Gi (set previously); adding the
+      # missing CPU limit here. 500m gives generous headroom for bursty
+      # log ingestion.
       resources:
         limits:
+          cpu: 500m
           memory: 1Gi
         requests:
           cpu: 100m
@@ -66,6 +70,27 @@ spec:
         enabled: true
         storageClass: longhorn
         size: 200Gi
+
+    # loki-sc-rules sidecar (kiwi k8s-sidecar) — watches ConfigMaps for
+    # rule files. Tiny Python watcher.
+    sidecar:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 50m
+          memory: 64Mi
+
+    # Canary DaemonSet — one per node. Idle 1-4m/14-41Mi.
+    lokiCanary:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
 
     # Disable other deployment modes
     backend:


### PR DESCRIPTION
## Summary
Adds resource requests/limits to the 3 loki workloads. Closes the loki slice of STRIDE D1.

| container | request | limit | Notes |
|---|---|---|---|
| loki (singleBinary) | 100m / 256Mi | 500m / 1Gi | Memory limit was already set; added missing CPU limit |
| loki-sc-rules | 10m / 32Mi | 50m / 64Mi | New — sidecar Python file watcher |
| loki-canary (×5 DaemonSet) | 25m / 64Mi | 100m / 128Mi | New |

## Sizing source
- loki container: observed 50m / 350Mi at steady state with current scrape volume
- loki-canary: observed 1-4m / 14-41Mi per node (idle log-write-and-query loop)

## Validation
Rendered the chart with the new values — all 3 containers carry their resource blocks.

## Impact on apply
- loki StatefulSet rolling update — ~30s log ingestion gap; otel-agent buffers locally during the window
- loki-sc-rules sidecar restarts with the loki pod
- lokiCanary DaemonSet rolling update — one pod per node sequentially

## Test plan
- [ ] `kubectl get pod -n monitoring loki-0 -o jsonpath='{.spec.containers[*].resources}'` shows non-empty for both `loki` and `loki-sc-rules`
- [ ] All 5 loki-canary pods show non-empty resources after the DaemonSet rollout
- [ ] Grafana → Explore → Loki panel still returns logs (loki ingestion working)
- [ ] No OOM events: `kubectl get events -n monitoring --field-selector reason=OOMKilling`

## Remaining D1 slices in monitoring after this lands
- **opentelemetry-collector-agent** (separate chart, separate PR)