### PR TITLE
fix(loki): bump sidecar memory limit to 256Mi (was OOMKilled at 64Mi)

### DIFF
--- a/clusters/k3s-cluster/apps/loki/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/loki/helmrelease.yaml
@@ -72,15 +72,18 @@ spec:
         size: 200Gi
 
     # loki-sc-rules sidecar (kiwi k8s-sidecar) — watches ConfigMaps for
-    # rule files. Tiny Python watcher.
+    # rule files. Idle 22Mi but spikes during initial ConfigMap list/watch
+    # establishment (Python in-memory caching). PR #35 set 64Mi limit and
+    # the sidecar OOMKilled in startup loop with exitCode=137. Bumped to
+    # 256Mi based on live-patched value that recovered the pod.
     sidecar:
       resources:
         requests:
           cpu: 10m
-          memory: 32Mi
-        limits:
-          cpu: 50m
           memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 256Mi
 
     # Canary DaemonSet — one per node. Idle 1-4m/14-41Mi.
     lokiCanary:


### PR DESCRIPTION
## Summary
PR #35 set `loki-sc-rules` (the kiwigrid k8s-sidecar that watches ConfigMaps for rule files) at 64Mi memory limit. After Flux applied the change, the sidecar entered a CrashLoopBackOff with `exitCode 137` (OOMKilled), restarting roughly every 3 minutes.

`loki-0` stayed at `1/2 Ready` (loki itself ran fine, but the sidecar couldn't stay up).

## Root cause
Steady-state RSS for the sidecar is only ~22Mi, but it spikes during initial ConfigMap list/watch establishment — the Python sidecar builds an in-memory cache of all matching ConfigMaps before settling. With the chart deployment doing a full restart on every Helm upgrade (and the existing rules ConfigMap potentially carrying historic content), peak memory exceeded 64Mi.

## Fix
- memory: 32Mi → 64Mi request, 64Mi → **256Mi** limit (4× the previous limit; matches what the live patch needed)
- cpu: 50m → 100m limit (was getting throttled during the same startup window)

## Already applied to live cluster
The live StatefulSet was patched with these exact values to break the OOM loop:
```
$ kubectl set resources sts -n monitoring loki -c loki-sc-rules \
    --requests cpu=10m,memory=64Mi --limits cpu=100m,memory=256Mi
$ kubectl get pod -n monitoring loki-0
loki-0   2/2   Running   0   51s
```
The sidecar settled at 22Mi steady state immediately after.

## Lesson
Sidecar Python watchers benefit from generous memory headroom even at "idle" usage levels — the startup spike can be 5-10× steady state. Don't size from `kubectl top` alone if the sidecar wasn't observed during a fresh start.

## Test plan
- [ ] After Flux reconcile, `kubectl get pod -n monitoring loki-0` shows `2/2 Running`
- [ ] Both containers' resources match the manifest
- [ ] Loki log queries return data in Grafana (`{namespace="kube-system"}` panel)