### PR TITLE
fix(grafana/sidecar): bump memory limit 64Mi → 256Mi to dodge OOM trap

### DIFF
--- a/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
+++ b/clusters/k3s-cluster/apps/kube-prometheus-stack/helmrelease.yaml
@@ -82,15 +82,20 @@ spec:
           cpu: 500m
           memory: 2Gi
       # sc-dashboard and sc-datasources sidecars use the shared sidecar
-      # value path. Both are tiny (Python file watchers).
+      # value path. Idle ~20Mi but startup spike (initial ConfigMap
+      # list/watch) can hit 100-200Mi. PR #34 set 64Mi limit; loki's
+      # equivalent sidecar (loki-sc-rules) OOMKilled with the same value
+      # in PR #35 → had to bump to 256Mi in PR #36. Pre-empting that
+      # trap here for the grafana sidecars before they hit it on next
+      # chart upgrade or pod restart.
       sidecar:
         resources:
           requests:
             cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 50m
             memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
       # Ensure admin password is set or use default (prom-operator)
       adminPassword: "prom-operator"
 


### PR DESCRIPTION
## Summary
Pre-emptive fix to dodge the same OOM trap that hit `loki-sc-rules` in PR #35→#36. Both sidecars are kiwigrid k8s-sidecar (Python ConfigMap watcher), and PR #34 set the grafana sidecars at 64Mi memory limit based on 20Mi idle RSS — but the kiwigrid sidecar startup spikes to 100-200Mi during initial ConfigMap list/watch.

## Why now
The grafana pod hasn't restarted since PR #34 merged, so the trap hasn't fired yet. Next chart upgrade or any grafana pod restart would hit it. Memory entry `feedback_kiwigrid_sidecar_sizing.md` flagged both sidecars as at-risk.

## Change
| Field | Before | After |
|---|---|---|
| memory request | 32Mi | 64Mi |
| memory limit | **64Mi** | **256Mi** |
| cpu request | 10m | 10m |
| cpu limit | 50m | 100m |

Same values that resolved the equivalent crash on `loki-sc-rules` in PR #36.

## Validation
Rendered the chart; both `grafana-sc-dashboard` and `grafana-sc-datasources` carry the new resource block.

## Impact on apply
- Grafana Deployment uses `Recreate` strategy (RWO PVC) — single ~30s pod swap
- Sidecars get the new limits on the new pod
- Grafana UI brief unavailable during pod swap; clients retry

## Test plan
- [ ] After Flux reconcile, grafana pod has new sc-dashboard/sc-datasources resources
- [ ] No OOMKilled events on grafana sidecars
- [ ] Grafana UI loads at https://monitor.theedgeworks.ai
- [ ] Dashboards still discovered via the sc-dashboard sidecar (any dashboard ConfigMap shows up)